### PR TITLE
Added Server Broadcast Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,22 @@ This mod requires [Mod Menu](https://www.curseforge.com/minecraft/mc-mods/modmen
 If you encounter any bug or issue or have any suggestion, please add it as an issue
 [here](https://github.com/PabloPerezRodriguez/twitch-chat/issues/new).**
 
-### Usage:
+## Usage:
 1.  Get a Twitch oauth key here https://twitchapps.com/tmi/ and write it down somewhere.
 2.  Open the mod menu.
 3.  Open this mod's configuration inside that menu.
-4.  Fill in the config textboxes.
-5.  Go ingame and type /twitch watch \<channel\> (channel should be the name of the Twitch channel you want to join).
-You can use this command as many times as you want. 
-6.  Type /twitch enable.
+4.  Fill in the config textboxes (your twitch username, oauth token).
+5.  Go in game and type `/twitch watch CHANNEL` (where CHANNEL should be the name of the Twitch channel you want to join).
+6.  Type `/twitch enable`.
 
-### Translations
+## Commands:
+- `/twitch watch CHANNEL` – Changes the watched Twitch channel to `CHANNEL` 
+- `/twitch enable` – Starts the Twitch chat integration
+- `/twitch disable` – Stops the Twitch chat integration
+- `/twitch broadcast true` – Relays Twitch chat messages to the Minecraft server as player messages
+- `/twitch broadcast false` – Keeps Twitch chat messages local to the Minecraft client
+
+## Translations
 If you find the mod is not available on a language you know I would really appreciate it if you could create a pull
 request with a translation for that language.
 
@@ -35,7 +41,7 @@ by clicking on these links: [en_us.json](src/main/resources/assets/twitchchat/la
 
 Don't translate **%d** or **%s** signs, they're used to dynamically insert numbers and text (respectively).
 
-### Contact
+## Contact
 
 If you have any questions don't hesitate to email, tweet or DM me, you can find my public profiles on my
 [GitHub profile](https://github.com/PabloPerezRodriguez). I'll answer ASAP.

--- a/src/main/java/to/pabli/twitchchat/TwitchChatMod.java
+++ b/src/main/java/to/pabli/twitchchat/TwitchChatMod.java
@@ -7,10 +7,8 @@ import java.util.UUID;
 import net.fabricmc.api.ModInitializer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.network.MessageType;
-import net.minecraft.text.BaseText;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.MutableText;
-import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import to.pabli.twitchchat.config.ModConfig;
 import to.pabli.twitchchat.twitch_integration.Bot;
@@ -30,6 +28,7 @@ public class TwitchChatMod implements ModInitializer {
     MutableText timestampText = new LiteralText(time);
     MutableText usernameText = new LiteralText(username).formatted(textColor);
     MutableText messageBodyText;
+    String plainTextMessage = "[twitch] " + username + ": " + message;
 
     if (!isMeMessage) {
       messageBodyText = new LiteralText(": " + message);
@@ -48,10 +47,20 @@ public class TwitchChatMod implements ModInitializer {
       usernameText = new LiteralText("* ").append(usernameText);
     }
 
-    MinecraftClient.getInstance().inGameHud.addChatMessage(MessageType.CHAT,
-        timestampText
-        .append(usernameText)
-        .append(messageBodyText), UUID.randomUUID());
+    if (ModConfig.getConfig().isBroadcastEnabled()) {
+      try {
+        if (MinecraftClient.getInstance().player != null) {
+          MinecraftClient.getInstance().player.sendChatMessage(plainTextMessage);
+        }
+      } catch (NullPointerException e) {
+        System.err.println("TWITCH BOT FAILED TO BROADCAST MESSAGE: " + e.getMessage());
+      }
+    } else {
+      MinecraftClient.getInstance().inGameHud.addChatMessage(MessageType.CHAT,
+          timestampText
+          .append(usernameText)
+          .append(messageBodyText), UUID.randomUUID());
+    }
   }
   public static void addNotification(MutableText message) {
     MinecraftClient.getInstance().inGameHud.addChatMessage(MessageType.CHAT, message.formatted(Formatting.DARK_GRAY), UUID.randomUUID());

--- a/src/main/java/to/pabli/twitchchat/TwitchChatMod.java
+++ b/src/main/java/to/pabli/twitchchat/TwitchChatMod.java
@@ -28,7 +28,6 @@ public class TwitchChatMod implements ModInitializer {
     MutableText timestampText = new LiteralText(time);
     MutableText usernameText = new LiteralText(username).formatted(textColor);
     MutableText messageBodyText;
-    String plainTextMessage = "[twitch] " + username + ": " + message;
 
     if (!isMeMessage) {
       messageBodyText = new LiteralText(": " + message);
@@ -49,6 +48,7 @@ public class TwitchChatMod implements ModInitializer {
 
     if (ModConfig.getConfig().isBroadcastEnabled()) {
       try {
+        String plainTextMessage = ModConfig.getConfig().getBroadcastPrefix() + username + ": " + message;
         if (MinecraftClient.getInstance().player != null) {
           MinecraftClient.getInstance().player.sendChatMessage(plainTextMessage);
         }

--- a/src/main/java/to/pabli/twitchchat/commands/TwitchBaseCommand.java
+++ b/src/main/java/to/pabli/twitchchat/commands/TwitchBaseCommand.java
@@ -1,12 +1,10 @@
 package to.pabli.twitchchat.commands;
 
-import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
 
 import com.mojang.brigadier.CommandDispatcher;
 import io.github.cottonmc.clientcommands.ArgumentBuilders;
 import io.github.cottonmc.clientcommands.ClientCommandPlugin;
 import io.github.cottonmc.clientcommands.CottonClientCommandSource;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;
 
 public class TwitchBaseCommand implements ClientCommandPlugin {
@@ -18,6 +16,7 @@ public class TwitchBaseCommand implements ClientCommandPlugin {
         // The command to be executed if the command "twitch" is entered with the argument "disable"
         .then(TwitchDisableCommand.getArgumentBuilder())
         .then(TwitchWatchCommand.getArgumentBuilder())
+        .then(TwitchBroadcastCommand.getArgumentBuilder())
         .executes(source -> {
           source.getSource().sendFeedback(new TranslatableText("text.twitchchat.command.base.noargs1"));
           source.getSource().sendFeedback(new TranslatableText("text.twitchchat.command.base.noargs2"));

--- a/src/main/java/to/pabli/twitchchat/commands/TwitchBroadcastCommand.java
+++ b/src/main/java/to/pabli/twitchchat/commands/TwitchBroadcastCommand.java
@@ -1,0 +1,32 @@
+package to.pabli.twitchchat.commands;
+
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import io.github.cottonmc.clientcommands.ArgumentBuilders;
+import io.github.cottonmc.clientcommands.CottonClientCommandSource;
+import net.minecraft.text.TranslatableText;
+import to.pabli.twitchchat.config.ModConfig;
+
+public class TwitchBroadcastCommand {
+  public static LiteralArgumentBuilder<CottonClientCommandSource> getArgumentBuilder() {
+    return ArgumentBuilders.literal("broadcast")
+        // The command to be executed if the command "twitch" is entered with the argument "broadcast"
+        // It requires true/false as an argument.
+        // It will toggle the broadcast flag in the config and
+        // if enabled, will relay twitch messages as say-chat messages to the server.
+        .then(ArgumentBuilders.argument("enabled", BoolArgumentType.bool())
+            .executes(ctx -> {
+              boolean enabled = BoolArgumentType.getBool(ctx, "enabled");
+
+              ModConfig.getConfig().setBroadcastEnabled(enabled);
+              // Also switch channels if the bot has been initialized
+              if (enabled) {
+                ctx.getSource().sendFeedback(new TranslatableText("text.twitchchat.command.broadcast.enabled"));
+              } else {
+                ctx.getSource().sendFeedback(new TranslatableText("text.twitchchat.command.broadcast.disabled"));
+              }
+              ModConfig.getConfig().save();
+              return 1;
+        }));
+  }
+}

--- a/src/main/java/to/pabli/twitchchat/config/ModConfig.java
+++ b/src/main/java/to/pabli/twitchchat/config/ModConfig.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,6 +24,7 @@ public class ModConfig {
   public static final String DEFAULT_DATE_FORMAT = "[H:mm] ";
   public static final List<String> DEFAULT_IGNORE_LIST = new ArrayList<>();
   public static final boolean DEFAULT_TWITCH_WATCH_SUGGESTIONS = false;
+  public static final boolean DEFAULT_BROADCAST = false;
 
   private static ModConfig SINGLE_INSTANCE = null;
   private final File configFile;
@@ -36,6 +36,7 @@ public class ModConfig {
   private String dateFormat;
   private List<String> ignoreList;
   private boolean twitchWatchSuggestions;
+  private boolean broadcast;
 
   public ModConfig() {
     this.configFile = FabricLoader
@@ -51,6 +52,7 @@ public class ModConfig {
     this.dateFormat = DEFAULT_DATE_FORMAT;
     this.ignoreList = new ArrayList<>(DEFAULT_IGNORE_LIST);
     this.twitchWatchSuggestions = DEFAULT_TWITCH_WATCH_SUGGESTIONS;
+    this.broadcast = DEFAULT_BROADCAST;
   }
 
   public static ModConfig getConfig() {
@@ -91,6 +93,10 @@ public class ModConfig {
         this.twitchWatchSuggestions = jsonObject.has("twitchWatchSuggestions")
                 ? jsonObject.getAsJsonPrimitive("twitchWatchSuggestions").getAsBoolean()
                 : DEFAULT_TWITCH_WATCH_SUGGESTIONS;
+
+        this.broadcast = jsonObject.has("broadcast")
+                ? jsonObject.getAsJsonPrimitive("broadcast").getAsBoolean()
+                : DEFAULT_BROADCAST;
       }
     } catch (IOException e) {
       // Do nothing, we have no file and thus we have to keep everything as default
@@ -111,6 +117,7 @@ public class ModConfig {
     jsonObject.add("ignoreList", ignoreListJsonArray);
 
     jsonObject.addProperty("twitchWatchSuggestions", this.twitchWatchSuggestions);
+    jsonObject.addProperty("broadcast", this.broadcast);
     try (PrintWriter out = new PrintWriter(configFile)) {
        out.println(jsonObject.toString());
     } catch (FileNotFoundException e) {
@@ -173,5 +180,13 @@ public class ModConfig {
 
   public void setTwitchWatchSuggestions(boolean twitchWatchSuggestions) {
     this.twitchWatchSuggestions = twitchWatchSuggestions;
+  }
+
+  public boolean isBroadcastEnabled() {
+    return broadcast;
+  }
+
+  public void setBroadcastEnabled(boolean broadcastEnabled) {
+    this.broadcast = broadcastEnabled;
   }
 }

--- a/src/main/java/to/pabli/twitchchat/config/ModConfig.java
+++ b/src/main/java/to/pabli/twitchchat/config/ModConfig.java
@@ -25,6 +25,7 @@ public class ModConfig {
   public static final List<String> DEFAULT_IGNORE_LIST = new ArrayList<>();
   public static final boolean DEFAULT_TWITCH_WATCH_SUGGESTIONS = false;
   public static final boolean DEFAULT_BROADCAST = false;
+  public static final String DEFAULT_BROADCAST_PREFIX = "[twitch] ";
 
   private static ModConfig SINGLE_INSTANCE = null;
   private final File configFile;
@@ -37,6 +38,7 @@ public class ModConfig {
   private List<String> ignoreList;
   private boolean twitchWatchSuggestions;
   private boolean broadcast;
+  private String broadcastPrefix;
 
   public ModConfig() {
     this.configFile = FabricLoader
@@ -53,6 +55,7 @@ public class ModConfig {
     this.ignoreList = new ArrayList<>(DEFAULT_IGNORE_LIST);
     this.twitchWatchSuggestions = DEFAULT_TWITCH_WATCH_SUGGESTIONS;
     this.broadcast = DEFAULT_BROADCAST;
+    this.broadcastPrefix = DEFAULT_BROADCAST_PREFIX;
   }
 
   public static ModConfig getConfig() {
@@ -97,6 +100,10 @@ public class ModConfig {
         this.broadcast = jsonObject.has("broadcast")
                 ? jsonObject.getAsJsonPrimitive("broadcast").getAsBoolean()
                 : DEFAULT_BROADCAST;
+
+        this.broadcastPrefix = jsonObject.has("broadcastPrefix")
+                ? jsonObject.getAsJsonPrimitive("broadcastPrefix").getAsString()
+                : DEFAULT_BROADCAST_PREFIX;
       }
     } catch (IOException e) {
       // Do nothing, we have no file and thus we have to keep everything as default
@@ -118,6 +125,7 @@ public class ModConfig {
 
     jsonObject.addProperty("twitchWatchSuggestions", this.twitchWatchSuggestions);
     jsonObject.addProperty("broadcast", this.broadcast);
+    jsonObject.addProperty("broadcastPrefix", this.broadcastPrefix);
     try (PrintWriter out = new PrintWriter(configFile)) {
        out.println(jsonObject.toString());
     } catch (FileNotFoundException e) {
@@ -188,5 +196,13 @@ public class ModConfig {
 
   public void setBroadcastEnabled(boolean broadcastEnabled) {
     this.broadcast = broadcastEnabled;
+  }
+
+  public String getBroadcastPrefix() {
+    return broadcastPrefix;
+  }
+
+  public void setBroadcastPrefix(String broadcastPrefix) {
+    this.broadcastPrefix = broadcastPrefix;
   }
 }

--- a/src/main/java/to/pabli/twitchchat/config/ModMenuCompat.java
+++ b/src/main/java/to/pabli/twitchchat/config/ModMenuCompat.java
@@ -70,6 +70,12 @@ public class ModMenuCompat implements ModMenuApi {
               .setTooltip(new TranslatableText("config.twitchchat.cosmetics.broadcast.tooltip"))
               .setDefaultValue(ModConfig.DEFAULT_BROADCAST)
               .build());
+      cosmeticsCategory.addEntry(entryBuilder
+              .startStrField(new TranslatableText("config.twitchchat.cosmetics.broadcastPrefix"), ModConfig.getConfig().getBroadcastPrefix())
+              .setSaveConsumer((s -> ModConfig.getConfig().setBroadcastPrefix(s)))
+              .setTooltip(new TranslatableText("config.twitchchat.cosmetics.broadcastPrefix.tooltip"))
+              .setDefaultValue(ModConfig.DEFAULT_BROADCAST_PREFIX)
+              .build());
 
       return builder.build();
     };

--- a/src/main/java/to/pabli/twitchchat/config/ModMenuCompat.java
+++ b/src/main/java/to/pabli/twitchchat/config/ModMenuCompat.java
@@ -4,7 +4,6 @@ import io.github.prospector.modmenu.api.ConfigScreenFactory;
 import io.github.prospector.modmenu.api.ModMenuApi;
 
 import java.util.ArrayList;
-import java.util.function.Function;
 
 import me.shedaniel.clothconfig2.api.ConfigBuilder;
 import me.shedaniel.clothconfig2.api.ConfigCategory;
@@ -12,7 +11,6 @@ import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;
 
 @Environment(EnvType.CLIENT)
@@ -65,6 +63,12 @@ public class ModMenuCompat implements ModMenuApi {
               .setSaveConsumer((b -> ModConfig.getConfig().setTwitchWatchSuggestions(b)))
               .setTooltip(new TranslatableText("config.twitchchat.cosmetics.twitchWatchSuggestions.tooltip"))
               .setDefaultValue(ModConfig.DEFAULT_TWITCH_WATCH_SUGGESTIONS)
+              .build());
+      cosmeticsCategory.addEntry(entryBuilder
+              .startBooleanToggle(new TranslatableText("config.twitchchat.cosmetics.broadcast"), ModConfig.getConfig().isBroadcastEnabled())
+              .setSaveConsumer((b -> ModConfig.getConfig().setBroadcastEnabled(b)))
+              .setTooltip(new TranslatableText("config.twitchchat.cosmetics.broadcast.tooltip"))
+              .setDefaultValue(ModConfig.DEFAULT_BROADCAST)
               .build());
 
       return builder.build();

--- a/src/main/resources/assets/twitchchat/lang/en_gb.json
+++ b/src/main/resources/assets/twitchchat/lang/en_gb.json
@@ -15,6 +15,8 @@
   "config.twitchchat.cosmetics.ignorelist.tooltip": "Messages from users in this list won't be displayed",
   "config.twitchchat.cosmetics.twitchWatchSuggestions": "Suggestions for /twitch watch",
   "config.twitchchat.cosmetics.twitchWatchSuggestions.tooltip": "Autocomplete /twitch watch channel names with names from users in your server",
+  "config.twitchchat.cosmetics.broadcast": "Broadcast twitch messages",
+  "config.twitchchat.cosmetics.broadcast.tooltip": "Sends twitch chat messages to the server chat",
 
   "text.twitchchat.command.base.noargs1": "Welcome to the Minecraft-Twitch Bridge mod!",
   "text.twitchchat.command.base.noargs2": "To enable it just do /twitch enable when you're done setting up the config.",
@@ -29,6 +31,9 @@
 
   "text.twitchchat.command.watch.switching": "Switching channels to '%s'...",
   "text.twitchchat.command.watch.connect_on_enable": "The mod will connect to '%s' as soon as you enable it.",
+
+  "text.twitchchat.command.broadcast.enabled": "Broadcasting enabled",
+  "text.twitchchat.command.broadcast.disabled": "Broadcasting disabled",
 
   "text.twitchchat.chat.integration_disabled": "Twitch integration is not enabled, to enable it do /twitch enable.",
   "text.twitchchat.bot.connected": "Connected to channel '%s'",

--- a/src/main/resources/assets/twitchchat/lang/en_gb.json
+++ b/src/main/resources/assets/twitchchat/lang/en_gb.json
@@ -15,10 +15,10 @@
   "config.twitchchat.cosmetics.ignorelist.tooltip": "Messages from users in this list won't be displayed",
   "config.twitchchat.cosmetics.twitchWatchSuggestions": "Suggestions for /twitch watch",
   "config.twitchchat.cosmetics.twitchWatchSuggestions.tooltip": "Autocomplete /twitch watch channel names with names from users in your server",
-  "config.twitchchat.cosmetics.broadcast": "Broadcast twitch messages",
-  "config.twitchchat.cosmetics.broadcast.tooltip": "Sends twitch chat messages to the server chat",
+  "config.twitchchat.cosmetics.broadcast": "Broadcast Twitch messages",
+  "config.twitchchat.cosmetics.broadcast.tooltip": "Sends Twitch chat messages to the server chat",
   "config.twitchchat.cosmetics.broadcastPrefix": "Broadcast message prefix",
-  "config.twitchchat.cosmetics.broadcastPrefix.tooltip": "Put this at the start of messages when broadcasting to the server",
+  "config.twitchchat.cosmetics.broadcastPrefix.tooltip": "This is going to be added to the beginning of messages broadcasted to the server",
 
   "text.twitchchat.command.base.noargs1": "Welcome to the Minecraft-Twitch Bridge mod!",
   "text.twitchchat.command.base.noargs2": "To enable it just do /twitch enable when you're done setting up the config.",

--- a/src/main/resources/assets/twitchchat/lang/en_gb.json
+++ b/src/main/resources/assets/twitchchat/lang/en_gb.json
@@ -17,6 +17,8 @@
   "config.twitchchat.cosmetics.twitchWatchSuggestions.tooltip": "Autocomplete /twitch watch channel names with names from users in your server",
   "config.twitchchat.cosmetics.broadcast": "Broadcast twitch messages",
   "config.twitchchat.cosmetics.broadcast.tooltip": "Sends twitch chat messages to the server chat",
+  "config.twitchchat.cosmetics.broadcastPrefix": "Broadcast message prefix",
+  "config.twitchchat.cosmetics.broadcastPrefix.tooltip": "Put this at the start of messages when broadcasting to the server",
 
   "text.twitchchat.command.base.noargs1": "Welcome to the Minecraft-Twitch Bridge mod!",
   "text.twitchchat.command.base.noargs2": "To enable it just do /twitch enable when you're done setting up the config.",

--- a/src/main/resources/assets/twitchchat/lang/en_us.json
+++ b/src/main/resources/assets/twitchchat/lang/en_us.json
@@ -15,6 +15,8 @@
   "config.twitchchat.cosmetics.ignorelist.tooltip": "Messages from users in this list won't be displayed",
   "config.twitchchat.cosmetics.twitchWatchSuggestions": "Suggestions for /twitch watch",
   "config.twitchchat.cosmetics.twitchWatchSuggestions.tooltip": "Autocomplete /twitch watch channel names with names from users in your server",
+  "config.twitchchat.cosmetics.broadcast": "Broadcast twitch messages",
+  "config.twitchchat.cosmetics.broadcast.tooltip": "Sends twitch chat messages to the server chat",
 
   "text.twitchchat.command.base.noargs1": "Welcome to the Minecraft-Twitch Bridge mod!",
   "text.twitchchat.command.base.noargs2": "To enable it just do /twitch enable when you're done setting up the config.",
@@ -29,6 +31,9 @@
 
   "text.twitchchat.command.watch.switching": "Switching channels to '%s'...",
   "text.twitchchat.command.watch.connect_on_enable": "The mod will connect to '%s' as soon as you enable it.",
+
+  "text.twitchchat.command.broadcast.enabled": "Broadcasting enabled",
+  "text.twitchchat.command.broadcast.disabled": "Broadcasting disabled",
 
   "text.twitchchat.chat.integration_disabled": "Twitch integration is not enabled, to enable it do /twitch enable.",
   "text.twitchchat.bot.connected": "Connected to channel '%s'",

--- a/src/main/resources/assets/twitchchat/lang/en_us.json
+++ b/src/main/resources/assets/twitchchat/lang/en_us.json
@@ -15,10 +15,10 @@
   "config.twitchchat.cosmetics.ignorelist.tooltip": "Messages from users in this list won't be displayed",
   "config.twitchchat.cosmetics.twitchWatchSuggestions": "Suggestions for /twitch watch",
   "config.twitchchat.cosmetics.twitchWatchSuggestions.tooltip": "Autocomplete /twitch watch channel names with names from users in your server",
-  "config.twitchchat.cosmetics.broadcast": "Broadcast twitch messages",
-  "config.twitchchat.cosmetics.broadcast.tooltip": "Sends twitch chat messages to the server chat",
+  "config.twitchchat.cosmetics.broadcast": "Broadcast Twitch messages",
+  "config.twitchchat.cosmetics.broadcast.tooltip": "Sends Twitch chat messages to the server chat",
   "config.twitchchat.cosmetics.broadcastPrefix": "Broadcast message prefix",
-  "config.twitchchat.cosmetics.broadcastPrefix.tooltip": "Put this at the start of messages when broadcasting to the server",
+  "config.twitchchat.cosmetics.broadcastPrefix.tooltip": "This is going to be added to the beginning of messages broadcasted to the server",
 
   "text.twitchchat.command.base.noargs1": "Welcome to the Minecraft-Twitch Bridge mod!",
   "text.twitchchat.command.base.noargs2": "To enable it just do /twitch enable when you're done setting up the config.",

--- a/src/main/resources/assets/twitchchat/lang/en_us.json
+++ b/src/main/resources/assets/twitchchat/lang/en_us.json
@@ -17,6 +17,8 @@
   "config.twitchchat.cosmetics.twitchWatchSuggestions.tooltip": "Autocomplete /twitch watch channel names with names from users in your server",
   "config.twitchchat.cosmetics.broadcast": "Broadcast twitch messages",
   "config.twitchchat.cosmetics.broadcast.tooltip": "Sends twitch chat messages to the server chat",
+  "config.twitchchat.cosmetics.broadcastPrefix": "Broadcast message prefix",
+  "config.twitchchat.cosmetics.broadcastPrefix.tooltip": "Put this at the start of messages when broadcasting to the server",
 
   "text.twitchchat.command.base.noargs1": "Welcome to the Minecraft-Twitch Bridge mod!",
   "text.twitchchat.command.base.noargs2": "To enable it just do /twitch enable when you're done setting up the config.",

--- a/src/main/resources/assets/twitchchat/lang/es_es.json
+++ b/src/main/resources/assets/twitchchat/lang/es_es.json
@@ -15,6 +15,8 @@
   "config.twitchchat.cosmetics.ignorelist.tooltip": "Los mensajes de usuarios en esta lista no serán mostrados",
   "config.twitchchat.cosmetics.twitchWatchSuggestions": "Sugerencias para /twitch watch",
   "config.twitchchat.cosmetics.twitchWatchSuggestions.tooltip": "Autocompletar los nombres de canales de /twitch watch con usuarios en tu servidor",
+  "config.twitchchat.cosmetics.broadcast": "Transmitir mensajes de Twitch",
+  "config.twitchchat.cosmetics.broadcast.tooltip": "Envía mensajes de chat de Twitch al chat del servidor",
 
   "text.twitchchat.command.base.noargs1": "¡Bienvenido al mod de puente de chat entre Minecraft y Twitch!",
   "text.twitchchat.command.base.noargs2": "Para inicializarlo simplemente escribe /twitch enable cuando hayas terminado de configurar los ajustes.",
@@ -29,6 +31,9 @@
 
   "text.twitchchat.command.watch.switching": "Cambiando canales a '%s'...",
   "text.twitchchat.command.watch.connect_on_enable": "El mod se conectará a '%s' según lo actives.",
+
+  "text.twitchchat.command.broadcast.enabled": "Emisión habilitada",
+  "text.twitchchat.command.broadcast.disabled": "Difusión inhabilitada",
 
   "text.twitchchat.chat.integration_disabled": "La integración de twitchj no está activada, para activarla escribe /twitch enable.",
   "text.twitchchat.bot.connected": "Conectado al canal '%s'",

--- a/src/main/resources/assets/twitchchat/lang/es_es.json
+++ b/src/main/resources/assets/twitchchat/lang/es_es.json
@@ -15,10 +15,10 @@
   "config.twitchchat.cosmetics.ignorelist.tooltip": "Los mensajes de usuarios en esta lista no serán mostrados",
   "config.twitchchat.cosmetics.twitchWatchSuggestions": "Sugerencias para /twitch watch",
   "config.twitchchat.cosmetics.twitchWatchSuggestions.tooltip": "Autocompletar los nombres de canales de /twitch watch con usuarios en tu servidor",
-  "config.twitchchat.cosmetics.broadcast": "Transmitir mensajes de Twitch",
-  "config.twitchchat.cosmetics.broadcast.tooltip": "Envía mensajes de chat de Twitch al chat del servidor",
-  "config.twitchchat.cosmetics.broadcastPrefix": "Prefijo de mensaje de difusión",
-  "config.twitchchat.cosmetics.broadcastPrefix.tooltip": "Ponga esto al comienzo de los mensajes al transmitir al servidor",
+  "config.twitchchat.cosmetics.broadcast": "Retransmitir mensajes de Twitch",
+  "config.twitchchat.cosmetics.broadcast.tooltip": "Retransmite los mensajes de chat de Twitch al chat del servidor",
+  "config.twitchchat.cosmetics.broadcastPrefix": "Prefijo de los mensajes retransmitidos",
+  "config.twitchchat.cosmetics.broadcastPrefix.tooltip": "Esto se va a añadir al principio de los mensajes que se retransmiten al servidor",
 
   "text.twitchchat.command.base.noargs1": "¡Bienvenido al mod de puente de chat entre Minecraft y Twitch!",
   "text.twitchchat.command.base.noargs2": "Para inicializarlo simplemente escribe /twitch enable cuando hayas terminado de configurar los ajustes.",
@@ -34,8 +34,8 @@
   "text.twitchchat.command.watch.switching": "Cambiando canales a '%s'...",
   "text.twitchchat.command.watch.connect_on_enable": "El mod se conectará a '%s' según lo actives.",
 
-  "text.twitchchat.command.broadcast.enabled": "Emisión habilitada",
-  "text.twitchchat.command.broadcast.disabled": "Difusión inhabilitada",
+  "text.twitchchat.command.broadcast.enabled": "Retransmisión activada",
+  "text.twitchchat.command.broadcast.disabled": "Retransmisión desactivada",
 
   "text.twitchchat.chat.integration_disabled": "La integración de twitchj no está activada, para activarla escribe /twitch enable.",
   "text.twitchchat.bot.connected": "Conectado al canal '%s'",

--- a/src/main/resources/assets/twitchchat/lang/es_es.json
+++ b/src/main/resources/assets/twitchchat/lang/es_es.json
@@ -17,6 +17,8 @@
   "config.twitchchat.cosmetics.twitchWatchSuggestions.tooltip": "Autocompletar los nombres de canales de /twitch watch con usuarios en tu servidor",
   "config.twitchchat.cosmetics.broadcast": "Transmitir mensajes de Twitch",
   "config.twitchchat.cosmetics.broadcast.tooltip": "Envía mensajes de chat de Twitch al chat del servidor",
+  "config.twitchchat.cosmetics.broadcastPrefix": "Prefijo de mensaje de difusión",
+  "config.twitchchat.cosmetics.broadcastPrefix.tooltip": "Ponga esto al comienzo de los mensajes al transmitir al servidor",
 
   "text.twitchchat.command.base.noargs1": "¡Bienvenido al mod de puente de chat entre Minecraft y Twitch!",
   "text.twitchchat.command.base.noargs2": "Para inicializarlo simplemente escribe /twitch enable cuando hayas terminado de configurar los ajustes.",


### PR DESCRIPTION
This PR adds support to relay Twitch chat messages to the Minecraft server via player chat messages.

This adds two new commands: 
- `/twitch broadcast true` will enable relaying messages to the server, 
- `/twitch broadcast false` will disable the relay, keeping messages local to the client as usual.

Also, I enhanced the docs a bit. 

This works simply by formatting the Twitch message and having the player "say" it to the server as a regular in-game chat message. 

In my particular use case, I wanted a client-side mod that could relay Twitch chat messages for all players on the server to see, without the need for a server-side mod. This works in conjunction with other chat message workflow / mods so I can aggregate messages from many sources (e.g. Discord, in-game chat, Twitch) into a single, linear stream.

Thought I'd share my modifications back with you and perhaps others could find these changes useful as well.

Let me know if you have any questions or feedback! I'm sure my translations are not very good, so those will certainly need looking at.

Thanks,
-Kevin